### PR TITLE
Do not use 'AttributeFilterInput' class, as it is not present in older Magento versions

### DIFF
--- a/Model/Resolver/Product/ProductCustomAttributesLuigi.php
+++ b/Model/Resolver/Product/ProductCustomAttributesLuigi.php
@@ -91,10 +91,8 @@ class ProductCustomAttributesLuigi implements ResolverInterface
     ) {
         // If the classes exist, we can compute product's custom attributes
         if ($this->getAttributeValue && $this->getFilteredAttributes) {
-            $filtersArgs = $args['filters'] ?? [];
-
             $productCustomAttributes = $this->getFilteredAttributes->execute(
-                $filtersArgs,
+                [],
                 ProductAttributeInterface::ENTITY_TYPE_CODE
             );
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "luigisbox/magento2-integration",
   "description": "Luigi's Box product discovery services integration",
   "type": "magento2-module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": ["MIT"],
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Luigisbox_Integration" setup_version="1.1.0">
+    <module name="Luigisbox_Integration" setup_version="1.1.1">
         <sequence>
             <module name="Magento_Integration"/>
         </sequence>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,5 +1,5 @@
 interface ProductInterface {
-    custom_attributes_luigi(filters: AttributeFilterInput): String
-        @doc(description: "Same as 'custom_attributesV2', but able to deal with null values. Returns the result as JSON string. Returns 'null' as string for versions 2.4.6 and lower.")
+    custom_attributes_luigi: String
+        @doc(description: "Similar to 'custom_attributesV2', but able to deal with null values. Returns the result as JSON string. Returns 'null' as string for versions 2.4.6 and lower.")
         @resolver(class: "Luigisbox\\Integration\\Model\\Resolver\\Product\\ProductCustomAttributesLuigi")
 }


### PR DESCRIPTION
Class 'AttributeFilterInput' is not present in older Magento versions, therefore we have to do without it